### PR TITLE
feat: support fork repositories for community PRs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Alterations source branch"
     required: true
     default: ${{ github.head_ref }}
+  repository:
+    description: "Repository hosting the alterations branch. Defaults to the current repository; set to the PR head repo (e.g. a fork) to support community PRs."
+    required: false
+    default: ${{ github.repository }}
 
 runs:
   using: composite
@@ -16,6 +20,7 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
+        repository: ${{ inputs.repository }}
         ref: ${{ inputs.branch }}
         path: alterations
     - name: Prepack ci for alterations


### PR DESCRIPTION
## Summary

- Add a new optional `repository` input that lets callers point the inner `actions/checkout` at a different repo (typically the PR head's fork).
- Defaults to `${{ github.repository }}` so same-repo flows are unchanged.

## Why

The `alteration-compatibility-integration-test` workflow in [logto-io/logto](https://github.com/logto-io/logto) currently fails for any PR opened from a fork:

```
fatal: Refusing to fetch into current branch refs/remotes/origin/<head-ref>
The process '/usr/bin/git' failed with exit code 1
```

…because this action's checkout defaults to `github.repository` (= `logto-io/logto`), where the contributor's branch does not exist. `GITHUB_TOKEN` on `pull_request` events already has read access to the head fork, so once we pass the head repo through, the fetch succeeds.

## Rollout

This is backward compatible — existing callers (which don't pass `repository`) keep using the current repo. After merging, cut a new release (suggest `v1.1.0`); then [logto-io/actions-run-logto-integration-tests](https://github.com/logto-io/actions-run-logto-integration-tests) can bump to it and forward a new `db-alteration-repository` input from the workflow.

## Test plan

- [ ] Verify same-repo PR still works on `logto-io/logto` master (no behavior change since input defaults to `github.repository`)
- [ ] After release + downstream bump, verify a community PR (fork) passes `alteration-compatibility-integration-test` end-to-end